### PR TITLE
ci: add GitHub Actions build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
             libxkbcommon-dev \
+            libxkbcommon-x11-dev \
             libwayland-dev \
             libvulkan-dev \
             libegl1-mesa-dev \
             libgles2-mesa-dev \
+            libx11-xcb-dev \
             pkg-config \
             xorg-dev
 

--- a/internal/ui/sysfont_other.go
+++ b/internal/ui/sysfont_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package ui
+
+import (
+	"gioui.org/font/gofont"
+	"gioui.org/text"
+)
+
+// LoadFontCollection falls back to the bundled Go fonts on non-Windows platforms.
+func LoadFontCollection(fontName string) []text.FontFace {
+	return gofont.Collection()
+}


### PR DESCRIPTION
Adds a CI workflow that runs go build and go test on all PRs targeting main and on pushes to main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors the headless runner to support multiple emitters and adds a new `-stdio` execution mode, which could affect existing headless/automation output expectations. CI workflow changes are low risk but may introduce build/test environment flakiness due to added system deps.
> 
> **Overview**
> **Adds CI** via a new GitHub Actions workflow that installs required Linux GUI/system libraries, runs `go build ./...`, and runs `go test` for all packages except `cmd/` on PRs and `main` pushes.
> 
> **Extends headless mode** by introducing a shared `emitter` interface, a new `PlainEmitter` (with tests) that outputs mutex-safe, ANSI-stripped, LLM-friendly tagged lines, and a new `-stdio` flag that runs `headless.RunStdio` while keeping existing `-headless` NDJSON behavior via `runWithEmitter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b23f4e6cc18f9040d9ff66fc03b77ef4afa54da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->