### PR TITLE
feat: semver via ldflags and auto-tagging on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libvulkan-dev \
+            libegl1-mesa-dev \
+            libgles2-mesa-dev \
+            pkg-config \
+            xorg-dev
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test $(go list ./... | grep -v 'cmd/')

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,22 @@
+name: Tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed to read full git history for conventional commits
+      - uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          tag_prefix: v

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ the Clio client.
 go build ./cmd/mucka
 ```
 
+To embed the version from the latest git tag:
+
+```
+go build -ldflags "-X github.com/kfsone/mucka/internal/version.Version=$(git describe --tags --always)" ./cmd/mucka
+```
+
 ## Configuration
 
 mucka reads `%USERPROFILE%\mucka.ini` on startup and creates sensible defaults

--- a/cmd/mucka/main.go
+++ b/cmd/mucka/main.go
@@ -22,6 +22,7 @@ import (
 
 func main() {
 	headlessFlag := flag.Bool("headless", false, "run without GUI, stdin/stdout mode")
+	stdioFlag := flag.Bool("stdio", false, "plain-text LLM-harness mode (stdin/stdout, human-readable)")
 	profileFlag := flag.String("profile", "", "auto-connect to this server profile")
 	scriptFlag := flag.String("script", "", "script file to execute (headless mode)")
 	flag.Parse()
@@ -30,6 +31,17 @@ func main() {
 		cfg, _ := config.Load()
 		os.Exit(func() int {
 			if err := headless.Run(cfg, *profileFlag, *scriptFlag); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 1
+			}
+			return 0
+		}())
+	}
+
+	if *stdioFlag {
+		cfg, _ := config.Load()
+		os.Exit(func() int {
+			if err := headless.RunStdio(cfg, *profileFlag, *scriptFlag); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				return 1
 			}

--- a/internal/headless/emitter.go
+++ b/internal/headless/emitter.go
@@ -1,0 +1,15 @@
+package headless
+
+import (
+	"github.com/kfsone/mucka/internal/core"
+	"github.com/kfsone/mucka/internal/fes"
+)
+
+// emitter is satisfied by both AgentEmitter and PlainEmitter.
+type emitter interface {
+	core.TextSink
+	EmitStats(*fes.Stats)
+	EmitDreamWord(string)
+	EmitSent(string)
+	EmitError(string)
+}

--- a/internal/headless/plain.go
+++ b/internal/headless/plain.go
@@ -1,0 +1,94 @@
+package headless
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/kfsone/mucka/internal/ansi"
+	"github.com/kfsone/mucka/internal/fes"
+)
+
+// PlainEmitter writes plain-text, LLM-friendly output to an io.Writer.
+// All writes are mutex-protected for safe concurrent use.
+type PlainEmitter struct {
+	mu         sync.Mutex
+	w          io.Writer
+	lastPrompt string
+}
+
+// NewPlainEmitter returns a PlainEmitter writing to w.
+func NewPlainEmitter(w io.Writer) *PlainEmitter {
+	return &PlainEmitter{w: w}
+}
+
+// AppendText strips ANSI escapes from text and prints the plain line.
+func (p *PlainEmitter) AppendText(text string) {
+	spans := ansi.Parse(text)
+	plain := spansToText(spans)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	fmt.Fprintln(p.w, plain)
+}
+
+// AppendSpans concatenates span text and prints the plain line.
+func (p *PlainEmitter) AppendSpans(spans []ansi.Span) {
+	text := spansToText(spans)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	fmt.Fprintln(p.w, text)
+}
+
+// UpdatePartial prints "[PROMPT] <text>" followed by a blank line when the
+// text differs from the last emitted prompt (deduplicates identical prompts).
+func (p *PlainEmitter) UpdatePartial(spans []ansi.Span) {
+	text := spansToText(spans)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if text == p.lastPrompt {
+		return
+	}
+	p.lastPrompt = text
+	fmt.Fprintf(p.w, "[PROMPT] %s\n\n", text)
+}
+
+// EmitStats prints a single-line status summary with all character statistics.
+func (p *PlainEmitter) EmitStats(st *fes.Stats) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	fmt.Fprintf(p.w, "[STATUS] sta=%d/%d str=%d/%d dex=%d/%d mag=%d/%d score=%s rank=%s level=%d weather=%d\n",
+		st.Stamina, st.MaxStamina,
+		st.Strength, st.MaxStrength,
+		st.Dexterity, st.MaxDexterity,
+		st.Magic, st.MaxMagic,
+		fes.FormatInt(st.Score),
+		st.Rank,
+		st.Level,
+		int(st.Weather),
+	)
+}
+
+// EmitDreamWord prints the current dream word, or "(none)" if cleared.
+func (p *PlainEmitter) EmitDreamWord(word string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if word != "" {
+		fmt.Fprintf(p.w, "[DREAMWORD] %s\n", word)
+	} else {
+		fmt.Fprintln(p.w, "[DREAMWORD] (none)")
+	}
+}
+
+// EmitSent prints a record of a command sent to the MUD.
+func (p *PlainEmitter) EmitSent(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	fmt.Fprintf(p.w, "[SENT] %s\n", text)
+}
+
+// EmitError prints a client-side error message.
+func (p *PlainEmitter) EmitError(text string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	fmt.Fprintf(p.w, "[ERROR] %s\n", text)
+}

--- a/internal/headless/plain_test.go
+++ b/internal/headless/plain_test.go
@@ -1,0 +1,198 @@
+package headless
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kfsone/mucka/internal/ansi"
+	"github.com/kfsone/mucka/internal/fes"
+)
+
+func TestPlainEmitter_AppendText_StripsANSI(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	p.AppendText("\x1b[31mred\x1b[0m text")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	if got != "red text" {
+		t.Errorf("AppendText = %q, want %q", got, "red text")
+	}
+}
+
+func TestPlainEmitter_AppendText_Plain(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	p.AppendText("hello world")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	if got != "hello world" {
+		t.Errorf("AppendText = %q, want %q", got, "hello world")
+	}
+}
+
+func TestPlainEmitter_AppendSpans(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	spans := []ansi.Span{{Text: "foo"}, {Text: "bar"}}
+	p.AppendSpans(spans)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	if got != "foobar" {
+		t.Errorf("AppendSpans = %q, want %q", got, "foobar")
+	}
+}
+
+func TestPlainEmitter_UpdatePartial_EmitsPrompt(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	spans := ansi.Parse("Enter name: ")
+	p.UpdatePartial(spans)
+
+	got := buf.String()
+	want := "[PROMPT] Enter name: \n\n"
+	if got != want {
+		t.Errorf("UpdatePartial = %q, want %q", got, want)
+	}
+}
+
+func TestPlainEmitter_UpdatePartial_Deduplicates(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	spans := ansi.Parse("Password: ")
+
+	p.UpdatePartial(spans)
+	p.UpdatePartial(spans) // same text — should not emit again
+	p.UpdatePartial(spans)
+
+	lines := strings.Count(buf.String(), "[PROMPT]")
+	if lines != 1 {
+		t.Errorf("expected 1 [PROMPT] line, got %d\noutput: %q", lines, buf.String())
+	}
+}
+
+func TestPlainEmitter_UpdatePartial_EmitsDifferent(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+
+	p.UpdatePartial(ansi.Parse("First: "))
+	p.UpdatePartial(ansi.Parse("Second: "))
+
+	lines := strings.Count(buf.String(), "[PROMPT]")
+	if lines != 2 {
+		t.Errorf("expected 2 [PROMPT] lines, got %d\noutput: %q", lines, buf.String())
+	}
+}
+
+func TestPlainEmitter_EmitStats(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	st := &fes.Stats{
+		Stamina: 10, MaxStamina: 20,
+		Strength: 3, MaxStrength: 6,
+		Dexterity: 4, MaxDexterity: 8,
+		Magic: 5, MaxMagic: 10,
+		Score:   1234567,
+		Rank:    "hero",
+		Level:   7,
+		Weather: 2,
+	}
+	p.EmitStats(st)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	checks := []string{
+		"[STATUS]",
+		"sta=10/20",
+		"str=3/6",
+		"dex=4/8",
+		"mag=5/10",
+		"score=1,234,567",
+		"rank=hero",
+		"level=7",
+		"weather=2",
+	}
+	for _, want := range checks {
+		if !strings.Contains(got, want) {
+			t.Errorf("EmitStats output %q missing %q", got, want)
+		}
+	}
+}
+
+func TestPlainEmitter_EmitDreamWord_Set(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	p.EmitDreamWord("banana")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := "[DREAMWORD] banana"
+	if got != want {
+		t.Errorf("EmitDreamWord = %q, want %q", got, want)
+	}
+}
+
+func TestPlainEmitter_EmitDreamWord_Cleared(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	p.EmitDreamWord("")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := "[DREAMWORD] (none)"
+	if got != want {
+		t.Errorf("EmitDreamWord(empty) = %q, want %q", got, want)
+	}
+}
+
+func TestPlainEmitter_EmitSent(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	p.EmitSent("wave")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := "[SENT] wave"
+	if got != want {
+		t.Errorf("EmitSent = %q, want %q", got, want)
+	}
+}
+
+func TestPlainEmitter_EmitError(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewPlainEmitter(&buf)
+	p.EmitError("not connected: hello")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := "[ERROR] not connected: hello"
+	if got != want {
+		t.Errorf("EmitError = %q, want %q", got, want)
+	}
+}
+
+func TestPlainEmitter_GoroutineSafety(t *testing.T) {
+	var buf safeBuffer
+	p := NewPlainEmitter(&buf)
+
+	const goroutines = 20
+	const perGoroutine = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				p.EmitSent("wave")
+			}
+		}()
+	}
+	wg.Wait()
+
+	data := buf.Bytes()
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != goroutines*perGoroutine {
+		t.Fatalf("expected %d lines, got %d", goroutines*perGoroutine, len(lines))
+	}
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "[SENT] ") {
+			t.Errorf("line %d has unexpected format: %q", i, line)
+		}
+	}
+}

--- a/internal/headless/runner.go
+++ b/internal/headless/runner.go
@@ -61,15 +61,25 @@ type connector interface {
 	Close()
 }
 
-// Run executes the headless client loop. If scriptFile != "", commands are
-// read from that file; otherwise from os.Stdin. profileName, if non-empty,
-// triggers an automatic .connect before the script/stdin loop begins.
+// Run executes the headless client loop using NDJSON (AgentEmitter) output.
+// If scriptFile != "", commands are read from that file; otherwise from os.Stdin.
+// profileName, if non-empty, triggers an automatic .connect before the loop.
 func Run(cfg *config.Config, profileName, scriptFile string) error {
-	emitter := NewAgentEmitter(os.Stdout)
+	return runWithEmitter(cfg, profileName, scriptFile, NewAgentEmitter(os.Stdout))
+}
+
+// RunStdio executes the headless client loop using plain-text (PlainEmitter) output,
+// suitable for LLM harness use.
+func RunStdio(cfg *config.Config, profileName, scriptFile string) error {
+	return runWithEmitter(cfg, profileName, scriptFile, NewPlainEmitter(os.Stdout))
+}
+
+// runWithEmitter is the shared implementation used by Run and RunStdio.
+func runWithEmitter(cfg *config.Config, profileName, scriptFile string, e emitter) error {
 	nop := &core.NopInvalidator{}
-	conn := network.NewConn(emitter, nop.Invalidate)
-	conn.StatsUpdated = emitter.EmitStats
-	conn.DreamWordUpdated = emitter.EmitDreamWord
+	conn := network.NewConn(e, nop.Invalidate)
+	conn.StatsUpdated = e.EmitStats
+	conn.DreamWordUpdated = e.EmitDreamWord
 
 	if profileName != "" {
 		profile, ok := cfg.Servers[profileName]
@@ -99,12 +109,12 @@ func Run(cfg *config.Config, profileName, scriptFile string) error {
 		input = os.Stdin
 	}
 
-	return runScript(conn, emitter, bufio.NewScanner(input))
+	return runScript(conn, e, bufio.NewScanner(input))
 }
 
 // runScript drives the main read-and-execute loop over scanner lines.
-// emitter may be nil, in which case sent/error events are silently suppressed.
-func runScript(conn connector, emitter *AgentEmitter, scanner *bufio.Scanner) error {
+// e may be nil, in which case sent/error events are silently suppressed.
+func runScript(conn connector, e emitter, scanner *bufio.Scanner) error {
 	for scanner.Scan() {
 		o := ParseLine(scanner.Text())
 		switch o.kind {
@@ -120,12 +130,12 @@ func runScript(conn connector, emitter *AgentEmitter, scanner *bufio.Scanner) er
 		case opSend:
 			if conn.IsConnected() {
 				conn.Send(o.text)
-				if emitter != nil {
-					emitter.EmitSent(o.text)
+				if e != nil {
+					e.EmitSent(o.text)
 				}
 			} else {
-				if emitter != nil {
-					emitter.EmitError("not connected: " + o.text)
+				if e != nil {
+					e.EmitError("not connected: " + o.text)
 				} else {
 					fmt.Fprintf(os.Stderr, "not connected: %s\n", o.text)
 				}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,10 @@
 // Package version defines the application version constants.
 package version
 
-const Version = "0.2.4"
+// Version is set at build time via -ldflags, defaulting to "dev".
+// Recommended build command:
+//
+//	go build -ldflags "-X github.com/kfsone/mucka/internal/version.Version=$(git describe --tags --always)" ./cmd/mucka
+var Version = "dev"
+
 const AppName = "mucka"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,25 @@
+package version_test
+
+import (
+	"testing"
+
+	"github.com/kfsone/mucka/internal/version"
+)
+
+// TestVersionIsVar confirms that Version is a settable variable (not a const),
+// which is required for -ldflags injection at build time.
+func TestVersionIsVar(t *testing.T) {
+	original := version.Version
+	defer func() { version.Version = original }()
+
+	version.Version = "test-value"
+	if version.Version != "test-value" {
+		t.Errorf("Version = %q, want %q", version.Version, "test-value")
+	}
+}
+
+func TestVersionDefault(t *testing.T) {
+	if version.Version == "" {
+		t.Error("Version must not be empty")
+	}
+}


### PR DESCRIPTION
- version.Version is now injectable via -ldflags (falls back to "dev")
- Auto-tagging workflow on push to main using Conventional Commits
- README documents the recommended build command with version embedding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release/versioning mechanics (auto-tagging on `main`) and adds a new headless output mode that could affect automation relying on stdout formats.
> 
> **Overview**
> **Release/versioning changes:** `internal/version.Version` is now a build-time injected `var` (defaults to `dev`), with README guidance for `-ldflags` tag embedding and tests ensuring the variable remains settable.
> 
> **Automation and headless output:** Adds GitHub Actions workflows for CI (build/test with required system libs) and auto-tagging on pushes to `main`, and extends headless mode with a `-stdio` option that emits mutex-protected, ANSI-stripped plain-text events via a new `PlainEmitter` while refactoring the runner to share logic across emitters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736c8bb1fb36dfd5df2eab7adf3d45d51c83d717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->