### PR TITLE
fix(network): remove erroneous 0xFF from dream word pattern (#23)

### DIFF
--- a/internal/network/dreamword.go
+++ b/internal/network/dreamword.go
@@ -19,31 +19,31 @@ func extractDreamWord(raw []byte) (processed []byte, finalWord string, changed b
 	i := 0
 	for i < len(raw) {
 		b := raw[i]
-		if b == 0xAA && i+3 < len(raw) && raw[i+1] == 0x9B && raw[i+3] == 0xFF {
+		if b == 0xAA && i+2 < len(raw) && raw[i+1] == 0x9B {
 			switch raw[i+2] {
 			case 0x9B: // SET: find 1-14 lowercase letters
-				j := i + 4
+				j := i + 3
 				for j < len(raw) && raw[j] >= 'a' && raw[j] <= 'z' {
 					j++
 				}
-				word := string(raw[i+4 : j])
+				word := string(raw[i+3 : j])
 				if word != "" {
 					finalWord = word
 					changed = true
 					out = append(out, "\x1B[36m"...)
-					out = append(out, raw[i+4:j]...)
+					out = append(out, raw[i+3:j]...)
 					out = append(out, "\x1B[0m"...)
 					i = j
 					continue
 				}
-				// SET with no letters: consume the 4-byte header silently so protocol
+				// SET with no letters: consume the 3-byte header silently so protocol
 				// bytes never appear in output (even when changed=true due to a later marker).
-				i += 4
+				i += 3
 				continue
 			case 0x9C: // CLEAR
 				finalWord = ""
 				changed = true
-				i += 4
+				i += 3
 				continue
 			}
 		}

--- a/internal/network/dreamword_test.go
+++ b/internal/network/dreamword_test.go
@@ -24,8 +24,8 @@ func TestExtractDreamWord_NoMarkers(t *testing.T) {
 }
 
 func TestExtractDreamWord_SetOnly(t *testing.T) {
-	// SET marker: \xAA\x9B\x9B\xFF followed by word
-	raw := []byte{0xAA, 0x9B, 0x9B, 0xFF, 'f', 'r', 'o', 'g'}
+	// SET marker: \xAA\x9B\x9B followed by word
+	raw := []byte{0xAA, 0x9B, 0x9B, 'f', 'r', 'o', 'g'}
 	got, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true")
@@ -40,8 +40,8 @@ func TestExtractDreamWord_SetOnly(t *testing.T) {
 }
 
 func TestExtractDreamWord_ClearOnly(t *testing.T) {
-	// CLEAR marker: \xAA\x9B\x9C\xFF
-	raw := []byte{0xAA, 0x9B, 0x9C, 0xFF}
+	// CLEAR marker: \xAA\x9B\x9C
+	raw := []byte{0xAA, 0x9B, 0x9C}
 	got, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true")
@@ -56,7 +56,7 @@ func TestExtractDreamWord_ClearOnly(t *testing.T) {
 
 func TestExtractDreamWord_SetThenClear(t *testing.T) {
 	// SET "foo" then CLEAR → last wins: empty
-	raw := []byte{0xAA, 0x9B, 0x9B, 0xFF, 'f', 'o', 'o', 0xAA, 0x9B, 0x9C, 0xFF}
+	raw := []byte{0xAA, 0x9B, 0x9B, 'f', 'o', 'o', 0xAA, 0x9B, 0x9C}
 	_, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true")
@@ -68,7 +68,7 @@ func TestExtractDreamWord_SetThenClear(t *testing.T) {
 
 func TestExtractDreamWord_ClearThenSet(t *testing.T) {
 	// CLEAR then SET "foo" → last wins: "foo"
-	raw := []byte{0xAA, 0x9B, 0x9C, 0xFF, 0xAA, 0x9B, 0x9B, 0xFF, 'f', 'o', 'o'}
+	raw := []byte{0xAA, 0x9B, 0x9C, 0xAA, 0x9B, 0x9B, 'f', 'o', 'o'}
 	_, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true")
@@ -79,8 +79,8 @@ func TestExtractDreamWord_ClearThenSet(t *testing.T) {
 }
 
 func TestExtractDreamWord_SetNoFollowingLetters(t *testing.T) {
-	// \xAA\x9B\x9B\xFF with no letters after — no word extracted, treated as raw bytes
-	raw := []byte{0xAA, 0x9B, 0x9B, 0xFF, '!'}
+	// \xAA\x9B\x9B with no letters after — no word extracted, treated as raw bytes
+	raw := []byte{0xAA, 0x9B, 0x9B, '!'}
 	got, word, changed := extractDreamWord(raw)
 	if changed {
 		t.Error("expected changed=false when SET has no letters")
@@ -94,8 +94,8 @@ func TestExtractDreamWord_SetNoFollowingLetters(t *testing.T) {
 }
 
 func TestExtractDreamWord_SetAtEndOfBuffer(t *testing.T) {
-	// Partial marker at end — i+3 < len(raw) check fails, treated as raw
-	raw := []byte{0xAA, 0x9B, 0x9B} // only 3 bytes, need i+3 < len for check
+	// Partial marker at end — i+2 < len(raw) check fails, treated as raw
+	raw := []byte{0xAA, 0x9B} // only 2 bytes, need i+2 < len for check
 	got, word, changed := extractDreamWord(raw)
 	if changed {
 		t.Error("expected changed=false for partial marker at end")
@@ -111,8 +111,8 @@ func TestExtractDreamWord_SetAtEndOfBuffer(t *testing.T) {
 func TestExtractDreamWord_MultipleSetMarkers(t *testing.T) {
 	// Multiple SET markers — last word wins
 	raw := []byte{
-		0xAA, 0x9B, 0x9B, 0xFF, 'a', 'b', 'c',
-		0xAA, 0x9B, 0x9B, 0xFF, 'x', 'y', 'z',
+		0xAA, 0x9B, 0x9B, 'a', 'b', 'c',
+		0xAA, 0x9B, 0x9B, 'x', 'y', 'z',
 	}
 	_, word, changed := extractDreamWord(raw)
 	if !changed {
@@ -141,7 +141,7 @@ func TestExtractDreamWord_WrongSequence(t *testing.T) {
 func TestExtractDreamWord_14CharWord(t *testing.T) {
 	// Maximum 14-char word
 	longWord := []byte("abcdefghijklmn") // 14 chars
-	raw := append([]byte{0xAA, 0x9B, 0x9B, 0xFF}, longWord...)
+	raw := append([]byte{0xAA, 0x9B, 0x9B}, longWord...)
 	_, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true")
@@ -154,7 +154,7 @@ func TestExtractDreamWord_14CharWord(t *testing.T) {
 func TestExtractDreamWord_WordWithSurroundingText(t *testing.T) {
 	// Text before and after the marker should be preserved
 	prefix := []byte("before ")
-	marker := []byte{0xAA, 0x9B, 0x9B, 0xFF, 'w', 'o', 'r', 'd'}
+	marker := []byte{0xAA, 0x9B, 0x9B, 'w', 'o', 'r', 'd'}
 	suffix := []byte(" after")
 	raw := append(append(prefix, marker...), suffix...)
 	got, word, changed := extractDreamWord(raw)
@@ -186,9 +186,9 @@ func TestExtractDreamWord_NoAA(t *testing.T) {
 }
 
 func TestExtractDreamWord_SetExactHeader_NoWord(t *testing.T) {
-	// Complete 4-byte SET header with absolutely nothing after it.
+	// Complete 3-byte SET header with absolutely nothing after it.
 	// Should be consumed silently: changed=false, raw returned.
-	raw := []byte{0xAA, 0x9B, 0x9B, 0xFF}
+	raw := []byte{0xAA, 0x9B, 0x9B}
 	got, word, changed := extractDreamWord(raw)
 	if changed {
 		t.Error("expected changed=false for 4-byte SET header with no letters")
@@ -203,8 +203,8 @@ func TestExtractDreamWord_SetExactHeader_NoWord(t *testing.T) {
 
 func TestExtractDreamWord_MalformedSetThenClear(t *testing.T) {
 	// Malformed SET (no following letters) then CLEAR.
-	// The 4 protocol bytes must NOT leak into the output.
-	raw := []byte{0xAA, 0x9B, 0x9B, 0xFF, '!', 0xAA, 0x9B, 0x9C, 0xFF}
+	// The 3 protocol bytes must NOT leak into the output.
+	raw := []byte{0xAA, 0x9B, 0x9B, '!', 0xAA, 0x9B, 0x9C}
 	got, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true (CLEAR was found)")
@@ -221,7 +221,7 @@ func TestExtractDreamWord_MalformedSetThenClear(t *testing.T) {
 
 func TestExtractDreamWord_MalformedSetThenSet(t *testing.T) {
 	// Malformed SET (no letters) then valid SET: protocol bytes must not appear in output.
-	raw := []byte{0xAA, 0x9B, 0x9B, 0xFF, '!', 0xAA, 0x9B, 0x9B, 0xFF, 'c', 'a', 't'}
+	raw := []byte{0xAA, 0x9B, 0x9B, '!', 0xAA, 0x9B, 0x9B, 'c', 'a', 't'}
 	got, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true")
@@ -239,7 +239,7 @@ func TestExtractDreamWord_WordOver14Chars(t *testing.T) {
 	// The spec says 1–14 chars; the implementation is lenient and accepts more.
 	// This test documents the current (permissive) behaviour.
 	longWord := []byte("abcdefghijklmno") // 15 chars
-	raw := append([]byte{0xAA, 0x9B, 0x9B, 0xFF}, longWord...)
+	raw := append([]byte{0xAA, 0x9B, 0x9B}, longWord...)
 	_, word, changed := extractDreamWord(raw)
 	if !changed {
 		t.Error("expected changed=true")

--- a/internal/network/dreamword_test.go
+++ b/internal/network/dreamword_test.go
@@ -248,3 +248,33 @@ func TestExtractDreamWord_WordOver14Chars(t *testing.T) {
 		t.Errorf("got %q", word)
 	}
 }
+
+func TestExtractDreamWord_AAAloneAtEndOfBuffer(t *testing.T) {
+	// Single 0xAA byte with nothing after it — partial header, treated as raw.
+	raw := []byte{0xAA}
+	got, word, changed := extractDreamWord(raw)
+	if changed {
+		t.Error("expected changed=false for lone 0xAA")
+	}
+	if word != "" {
+		t.Errorf("expected empty word, got %q", word)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("expected raw returned, got %v", got)
+	}
+}
+
+func TestExtractDreamWord_UnknownThirdByte(t *testing.T) {
+	// 0xAA 0x9B followed by an unrecognised third byte — all bytes treated as raw.
+	raw := []byte{0xAA, 0x9B, 0x05, 'h', 'i'}
+	got, word, changed := extractDreamWord(raw)
+	if changed {
+		t.Error("expected changed=false for unknown 3rd byte")
+	}
+	if word != "" {
+		t.Errorf("expected empty word, got %q", word)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("expected raw returned, got %v", got)
+	}
+}


### PR DESCRIPTION
## Problem

xtractDreamWord required a 4-byte header ending in 