### PR TITLE
ci: improve workflow safety, speed, and correctness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
     branches: [main]
@@ -16,7 +13,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -29,12 +26,17 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      - name: Test (pure Go)
+        env:
+          CGO_ENABLED: "0"
+        run: go test $(go list ./... | grep -vE 'cmd/|internal/ui')
+
       - name: Cache apt packages
         id: cache-apt
         uses: actions/cache@v4
         with:
           path: ~/apt-archives
-          key: apt-gioui-${{ runner.os }}-v1
+          key: apt-gioui-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}-v1
 
       - name: Install system dependencies
         run: |
@@ -58,8 +60,8 @@ jobs:
             cp /var/cache/apt/archives/*.deb ~/apt-archives/ 2>/dev/null || true
           fi
 
+      - name: Test (UI)
+        run: go test ./internal/ui/...
+
       - name: Build
         run: go build ./...
-
-      - name: Test
-        run: go test $(go list ./... | grep -v 'cmd/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test (pure Go)
         env:
           CGO_ENABLED: "0"
-        run: go test $(go list ./... | grep -vE 'cmd/|internal/ui')
+        run: go test $(go list ./... | grep -vE 'cmd/|internal/ui|internal/commands')
 
       - name: Cache apt packages
         id: cache-apt
@@ -60,8 +60,8 @@ jobs:
             cp /var/cache/apt/archives/*.deb ~/apt-archives/ 2>/dev/null || true
           fi
 
-      - name: Test (UI)
-        run: go test ./internal/ui/...
+      - name: Test (CGo)
+        run: go test ./internal/ui/... ./internal/commands/...
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,8 @@
 name: Tag
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]
@@ -10,12 +13,12 @@ permissions:
 jobs:
   tag:
     name: Create version tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # needed to read full git history for conventional commits
-      - uses: mathieudutour/github-tag-action@v6.2
+      - uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b  # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch


### PR DESCRIPTION
Closes #61

## Changes

### Speed
- **Pure-Go tests run before apt install** — `ansi`, `config`, `fes`, `network`, `headless`, `core`, `version` packages have no CGo dependency and now run with `CGO_ENABLED=0` immediately after checkout+setup. Test failures in core logic surface in ~15s instead of after the full apt setup.
- UI tests move to an explicit separate step after the apt install, making the dependency clear.

### Safety
- **`mathieudutour/github-tag-action` pinned to commit SHA** (`a22cf08…  # v6.2`) — this action holds `contents: write` permission; a floating tag is a supply-chain risk.

### Correctness / Maintenance
- **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` moved to `tag.yml`** — that's where the old-runtime action actually lives; it was misplaced in `ci.yml`.
- **apt cache key now uses `hashFiles`** on the workflow file — auto-invalidates when the package list changes instead of requiring a manual `v1` → `v2` bump.
- **Runner pinned to `ubuntu-24.04`** — avoids silent breakage when GitHub bumps `ubuntu-latest`.

## Test plan
- [ ] CI workflow runs on this PR — verify pure-Go test step passes before apt install begins
- [ ] Verify UI test step and build step complete successfully
- [ ] Confirm `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` warning is gone from CI run (it now lives only in tag.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)