### PR TITLE
fix(network): auto-request sc on game entry to populate rank/level

### DIFF
--- a/internal/network/conn.go
+++ b/internal/network/conn.go
@@ -344,6 +344,9 @@ func (c *Conn) reader(conn net.Conn, profile config.ServerProfile) {
 					fesDone = make(chan struct{})
 					c.fesPending.Add(1)
 					c.sendCh <- string(fes.TriggerBytes)
+					// FES binary packets omit rank/level; request sc once so the status
+					// bar shows rank immediately without waiting for a manual 'sc'.
+					c.sendCh <- "sc\r\n"
 					go c.fesPollLoop(fesDone)
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes #24.

The FES binary polling protocol sends 15 numeric fields (stamina, strength, dexterity, magic, score, status flags, reset timer, weather) but **never includes rank or level**. As a result `Stats.Rank` — the player's level title displayed in the status bar — was always blank until the player manually typed `sc`.

- On game entry detection (`IsGameEntry`), queue a single `sc` command immediately after the initial FES trigger
- `ScanLine` already parses `"level: N rank"` lines from the `sc` response and updates `Stats.Level` and `Stats.Rank`
- Subsequent FES binary polls keep all numeric stats current and never touch `Rank`/`Level`, so the status bar stays accurate for the full session

The change is three lines: one `sendCh` write and a two-line comment explaining why.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Connect to mud2-com and verify rank appears in the status bar immediately on game entry without typing `sc`
- [ ] Verify rank persists across FES poll cycles (stays correct after 10 s, 20 s, …)
- [ ] Verify manually typing `sc` still works and updates rank if it has changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)