### PR TITLE
feat: tab expansion, input-focus pinning, and trimmed release size

### DIFF
--- a/Mucka.Terminal.Tests/TerminalTextTests.cs
+++ b/Mucka.Terminal.Tests/TerminalTextTests.cs
@@ -3,19 +3,20 @@ using Mucka.Terminal;
 
 namespace Mucka.Terminal.Tests;
 
-/// <summary>Tests for <see cref="TerminalText"/> — control-character stripping (tofu prevention).</summary>
+/// <summary>Tests for <see cref="TerminalText"/> — control-char stripping + tab expansion.</summary>
 public class TerminalTextTests
 {
     private static StyledSpan Span(string text, TextStyle? style = null) => new(text, style ?? TextStyle.Default);
     private static StyledLine Line(bool partial, params StyledSpan[] spans) => new(spans, partial);
 
     [Fact]
-    public void StripControls_RemovesCarriageReturnBackspaceTabAndDel()
+    public void StripControls_RemovesCarriageReturnBackspaceAndDel_ButKeepsTab()
     {
         Assert.Equal("Password:", TerminalText.StripControls("Password:\r"));
         Assert.Equal("ab", TerminalText.StripControls("a\bb"));
-        Assert.Equal("xy", TerminalText.StripControls("x\ty"));
-        Assert.Equal("z", TerminalText.StripControls("z"));
+        Assert.Equal("ab", TerminalText.StripControls("ab"));   // DEL stripped
+        Assert.Equal("x\ty", TerminalText.StripControls("x\ty"));     // tab preserved (expanded later)
+        Assert.Equal("z", TerminalText.StripControls("z"));
     }
 
     [Fact]
@@ -68,5 +69,51 @@ public class TerminalTextTests
     {
         var line = Line(partial: false, Span("clean text"));
         Assert.Same(line, TerminalText.Sanitize(line));
+    }
+
+    // ── Tab expansion ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExpandTabs_AtColumnZero_FillsToFirstStop()
+    {
+        var line = TerminalText.ExpandTabs(Line(false, Span("\tx")));
+        Assert.Equal("        x", line.Spans[0].Text);   // 8 spaces + x
+    }
+
+    [Fact]
+    public void ExpandTabs_AdvancesToNextStop()
+    {
+        var line = TerminalText.ExpandTabs(Line(false, Span("ab\tc")));
+        Assert.Equal("ab      c", line.Spans[0].Text);   // col 2 → +6 spaces → c at col 8
+    }
+
+    [Fact]
+    public void ExpandTabs_OnStopBoundary_AddsFullTab()
+    {
+        var line = TerminalText.ExpandTabs(Line(false, Span("12345678\t")));
+        Assert.Equal("12345678        ", line.Spans[0].Text);   // col 8 → +8 spaces
+    }
+
+    [Fact]
+    public void ExpandTabs_TracksColumnAcrossSpans()
+    {
+        var line = TerminalText.ExpandTabs(Line(false, Span("ab"), Span("\tc")));
+        Assert.Equal("ab      c", line.PlainText);   // running column carries across spans
+    }
+
+    [Fact]
+    public void ExpandTabs_PreservesStyleAndPartial()
+    {
+        var red = new TextStyle(Foreground: AnsiColor.Red);
+        var line = TerminalText.ExpandTabs(Line(partial: true, Span("\tx", red)));
+        Assert.True(line.IsPartial);
+        Assert.Equal(red, line.Spans[0].Style);
+    }
+
+    [Fact]
+    public void ExpandTabs_NoTabs_ReturnsSameInstance()
+    {
+        var line = Line(false, Span("no tabs here"));
+        Assert.Same(line, TerminalText.ExpandTabs(line));
     }
 }

--- a/Mucka.Terminal/TerminalText.cs
+++ b/Mucka.Terminal/TerminalText.cs
@@ -9,13 +9,17 @@ namespace Mucka.Terminal;
 /// as .notdef "tofu" boxes — e.g. a trailing carriage return from a CRLF line ending, or a
 /// stray backspace. (The old WebView silently ignored them; Skia does not.)
 ///
-/// Form-feed (0x0C) is deliberately preserved: <see cref="TerminalBuffer"/> consumes it as a
-/// clear-screen, so stripping it here would break that. Newlines never appear in a line's
-/// spans (the parser splits on them).
+/// Form-feed (0x0C) is preserved: <see cref="TerminalBuffer"/> consumes it as a clear-screen.
+/// Tab (0x09) is also preserved here and expanded to spaces by <see cref="ExpandTabs"/> (which
+/// is column-aware across spans). Newlines never appear in a line's spans (the parser splits
+/// on them).
 /// </summary>
 public static class TerminalText
 {
-    private static bool IsStrippable(char c) => (c < 0x20 && c != '\f') || c == 0x7F;
+    /// <summary>Default tab stop width, in columns.</summary>
+    public const int TabWidth = 8;
+
+    private static bool IsStrippable(char c) => (c < 0x20 && c != '\f' && c != '\t') || c == 0x7F;
 
     /// <summary>Remove strippable control characters. Returns the same instance if there are none.</summary>
     public static string StripControls(string s)
@@ -55,5 +59,41 @@ public static class TerminalText
             if (t.Length > 0) cleaned.Add(span with { Text = t });
         }
         return new StyledLine(cleaned, line.IsPartial);
+    }
+
+    /// <summary>
+    /// Expand tab characters to spaces at <paramref name="tabWidth"/>-column tab stops, tracking
+    /// the running column across spans so alignment is correct. <see cref="StyledLine.IsPartial"/>
+    /// is preserved; returns the same instance when there are no tabs. Run AFTER <see cref="Sanitize"/>
+    /// and BEFORE wrapping, since the wrapper counts columns by character.
+    /// </summary>
+    public static StyledLine ExpandTabs(StyledLine line, int tabWidth = TabWidth)
+    {
+        bool any = false;
+        for (int i = 0; i < line.Spans.Count && !any; i++)
+            if (line.Spans[i].Text.IndexOf('\t') >= 0) any = true;
+        if (!any) return line;
+
+        int col = 0;
+        var expanded = new List<StyledSpan>(line.Spans.Count);
+        foreach (var span in line.Spans)
+        {
+            string t = span.Text;
+            if (t.IndexOf('\t') < 0) { col += t.Length; expanded.Add(span); continue; }
+
+            var sb = new StringBuilder(t.Length + tabWidth);
+            foreach (char c in t)
+            {
+                if (c == '\t')
+                {
+                    int n = tabWidth - (col % tabWidth);   // advance to the next tab stop
+                    sb.Append(' ', n);
+                    col += n;
+                }
+                else { sb.Append(c); col++; }
+            }
+            expanded.Add(span with { Text = sb.ToString() });
+        }
+        return new StyledLine(expanded, line.IsPartial);
     }
 }

--- a/Mucka.csproj
+++ b/Mucka.csproj
@@ -118,4 +118,15 @@
 		<ProjectReference Include="Mucka.Terminal\Mucka.Terminal.csproj" />
 	</ItemGroup>
 
+	<!-- Strip .pdb symbol files from the publish output. SkiaSharp's native assets ship ~220 MB
+	     of native .pdb files (libSkiaSharp.pdb, libGLESv2.pdb, …) that bloat the release artifact
+	     and are never needed at runtime. -->
+	<Target Name="StripPdbsFromPublish" AfterTargets="Publish">
+		<ItemGroup>
+			<_PublishedPdbs Include="$(PublishDir)**\*.pdb" />
+		</ItemGroup>
+		<Delete Files="@(_PublishedPdbs)" />
+		<Message Importance="high" Text="[mucka] Stripped %(_PublishedPdbs.Filename).pdb from publish output" />
+	</Target>
+
 </Project>

--- a/Pages/GamePage.xaml.cs
+++ b/Pages/GamePage.xaml.cs
@@ -99,10 +99,14 @@ public partial class GamePage : ContentPage
 #if WINDOWS
             try
             {
-                // Hook window root for F1-F12 physical key events (fires regardless of focus).
+                // Hook window root for F1-F12 physical key events (fires regardless of focus)
+                // and to keep keyboard focus pinned to the input box (GettingFocus bounce).
                 if (Window?.Handler?.PlatformView is Microsoft.UI.Xaml.Window fwin &&
                     fwin.Content is Microsoft.UI.Xaml.UIElement froot)
+                {
                     froot.PreviewKeyDown += OnRootPreviewKeyDown;
+                    froot.GettingFocus += OnRootGettingFocus;
+                }
                 // Hook the native TextBox so Up/Down/Esc keys work in the entry.
                 InputEntry.HandlerChanged += OnInputHandlerChanged;
                 // Hook the terminal canvas for mouse-wheel scrollback.
@@ -171,7 +175,10 @@ public partial class GamePage : ContentPage
 #if WINDOWS
         if (Window?.Handler?.PlatformView is Microsoft.UI.Xaml.Window fwin &&
             fwin.Content is Microsoft.UI.Xaml.UIElement froot)
+        {
             froot.PreviewKeyDown -= OnRootPreviewKeyDown;
+            froot.GettingFocus -= OnRootGettingFocus;
+        }
         if (_inputTextBox != null)
         {
             _inputTextBox.PreviewKeyDown -= OnInputPreviewKeyDown;
@@ -421,6 +428,17 @@ public partial class GamePage : ContentPage
         Windows.System.VirtualKey.Shift   or Windows.System.VirtualKey.LeftShift   or Windows.System.VirtualKey.RightShift   or
         Windows.System.VirtualKey.Menu    or Windows.System.VirtualKey.LeftMenu    or Windows.System.VirtualKey.RightMenu    or
         Windows.System.VirtualKey.LeftWindows or Windows.System.VirtualKey.RightWindows or Windows.System.VirtualKey.CapitalLock;
+
+    // Keyboard belongs to the input box on the game page. If focus heads anywhere else — a panel
+    // toggle, a tab, the gear/Cfg button, the dreamword label — bounce it straight back to the
+    // input box so typing is never stranded. Skipped while reviewing scrollback (input is hidden)
+    // or while the config editor is open. Redirecting in GettingFocus avoids any focus flicker.
+    private void OnRootGettingFocus(Microsoft.UI.Xaml.UIElement sender, Microsoft.UI.Xaml.Input.GettingFocusEventArgs args)
+    {
+        if (_isFkeyEditorOpen || Terminal.IsHistoryMode || _inputTextBox is null) return;
+        if (ReferenceEquals(args.NewFocusedElement, _inputTextBox)) return;
+        args.TrySetNewFocusedElement(_inputTextBox);
+    }
 
     private void OnRootPreviewKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
     {

--- a/Rendering/TerminalView.cs
+++ b/Rendering/TerminalView.cs
@@ -99,7 +99,11 @@ public sealed class TerminalView : SKCanvasView
     {
         if (lines.Count == 0) return;
         for (int i = 0; i < lines.Count; i++)
-            _buffer.Append(TerminalText.Sanitize(lines[i]));   // drop control-char tofu (\r, \b, …)
+        {
+            // Strip control-char tofu (\r, \b, …) then expand tabs to 8-col stops before buffering.
+            var line = TerminalText.ExpandTabs(TerminalText.Sanitize(lines[i]));
+            _buffer.Append(line);
+        }
         if (!_historyMode) InvalidateSurface();
     }
 


### PR DESCRIPTION
Follow-up polish on the v0.5.0 SkiaSharp terminal.

## Tab expansion (#7)
`TerminalText.ExpandTabs` replaces tabs with spaces at **8-column tab stops**, tracking the running column across spans so alignment is correct (it no longer strips `\t`). Runs in `TerminalView.AppendLines` after sanitising and before wrapping. 6 new unit tests (42 total in `Mucka.Terminal.Tests`).

## Keep keyboard focus on the input box (#9)
Toggling the extras panel — and clicking other chrome (tabs, gear/Cfg, dreamword) — could move keyboard focus off the input box and strand typing. A `GettingFocus` handler on the window root now bounces focus back to the input box, **except** while reviewing scrollback (input hidden) or with the config editor open.

## Trim release artifact size
The Windows zip ballooned **40 MB → 200 MB** after the Skia switch — almost entirely SkiaSharp's native `.pdb` symbols (`libSkiaSharp.pdb` 80 MB, `SkiaSharp.Views.WinUI.Native.pdb` 68 MB, `libGLESv2.pdb` 67 MB, …), never needed at runtime. A post-publish target strips all `.pdb` from the publish output: **377 MB → 156 MB** on disk, **zip ~200 MB → ~61 MB**. (The ~20 MB over the original 40 MB is the legitimate SkiaSharp native runtime.)

## Test plan
- Mucka.Terminal.Tests 42/42; mudsharp.Tests 196/196; Windows builds 0/0; publish verified stripped + re-zipped locally.
- Focus bounce is WinUI-only and not runtime-verified here — confirm on the RC that panel/chrome no longer drops typing, and that scrollback + config editor still take focus.

## Not included
Stage 5 cleanup (delete dead HtmlScrollback + WebView2 env var). #8 (echo ordering) parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
